### PR TITLE
fix(oauth): support client_secret_basic on token endpoint

### DIFF
--- a/packages/apps/src/oauth/oauth.ts
+++ b/packages/apps/src/oauth/oauth.ts
@@ -20,6 +20,23 @@ const getIssuer = () => {
 const OAUTH_SCOPES: OAuthScope[] = ["openid", "profile", "email", "groups"];
 const isOAuthScope = (value: string): value is OAuthScope => OAUTH_SCOPES.includes(value as OAuthScope);
 
+function readBasicClientCredentials(authHeader: string | undefined | null):
+  | { clientId: string; clientSecret: string }
+  | null {
+  if (!authHeader?.startsWith("Basic ")) return null;
+
+  const encoded = authHeader.slice("Basic ".length);
+  const decoded = Buffer.from(encoded, "base64").toString("utf8");
+
+  const colon = decoded.indexOf(":");
+  if (colon === -1) return null;
+
+  return {
+    clientId: decoded.slice(0, colon),
+    clientSecret: decoded.slice(colon + 1),
+  };
+}
+
 const AuthorizeQuerySchema = z.object({
   client_id: z.string().min(1),
   redirect_uri: z.url(),
@@ -34,7 +51,7 @@ const TokenBodySchema = z.object({
   grant_type: z.literal("authorization_code"),
   code: z.string().min(1),
   redirect_uri: z.url(),
-  client_id: z.string().min(1),
+  client_id: z.string().min(1).optional(),
   client_secret: z.string().optional(),
   code_verifier: z.string().optional(),
 });
@@ -167,7 +184,16 @@ const app = new Hono<AuthContext>()
     v("form", TokenBodySchema),
     async (c) => {
       const body = c.req.valid("form");
-      const { code, redirect_uri, client_id, client_secret, code_verifier } = body;
+      let { code, redirect_uri, client_id, client_secret, code_verifier } = body;
+
+      const basicCredentials = readBasicClientCredentials(c.req.header("Authorization"));
+
+      client_id ??= basicCredentials?.clientId;
+      client_secret ??= basicCredentials?.clientSecret;
+
+      if (!client_id) {
+        return c.json({ message: "Missing client_id" }, 400);
+      }
 
       const client = await oauth.clients.validateCredentials({
         clientId: client_id,


### PR DESCRIPTION
## Problem
`packages/apps/src/oauth/service/tokens.ts` advertises support for `client_secret_basic`:

```ts
token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
```

The token endpoint in `packages/apps/src/oauth/oauth.ts` only accepted `client_id` / `client_secret` from the form body though. This broke clients that rely on `client_secret_basic`, for example Vaultwarden SSO.

## Summary
- add support for OAuth `client_secret_basic` credentials on the token endpoint
- allow `client_id` to be omitted from the form body when it is provided via `Authorization: Basic ...`
- return a clear `400` response when no `client_id` can be resolved

## Testing
- Not run; PR preparation only