### PR TITLE
fix(oauth): preserve oidc nonce in id tokens

### DIFF
--- a/packages/oauth/src/migrate.ts
+++ b/packages/oauth/src/migrate.ts
@@ -40,11 +40,16 @@ export const migrate = async (): Promise<void> => {
       client_id TEXT NOT NULL REFERENCES oauth.clients(client_id) ON DELETE CASCADE,
       user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
       redirect_uri TEXT NOT NULL,
+      nonce TEXT,
       code_challenge TEXT,
       code_challenge_method TEXT CHECK (code_challenge_method IN ('S256', 'plain')),
       expires_at TIMESTAMPTZ NOT NULL DEFAULT now() + INTERVAL '5 minutes',
       used BOOLEAN NOT NULL DEFAULT false
     )
+  `.simple();
+  await sql`
+    ALTER TABLE oauth.codes
+    ADD COLUMN IF NOT EXISTS nonce TEXT
   `.simple();
   await sql`
     CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires

--- a/packages/oauth/src/oauth.ts
+++ b/packages/oauth/src/oauth.ts
@@ -47,6 +47,7 @@ const AuthorizeQuerySchema = z.object({
   response_type: z.literal("code"),
   scope: z.string().optional().default("openid"),
   state: z.string().optional(),
+  nonce: z.string().optional(),
   code_challenge: z.string().optional(),
   code_challenge_method: z.enum(["S256", "plain"]).optional(),
 });
@@ -107,7 +108,7 @@ const app = new Hono<AuthContext>()
     v("query", AuthorizeQuerySchema),
     async (c) => {
       const query = c.req.valid("query");
-      const { client_id, redirect_uri, state, code_challenge, code_challenge_method } = query;
+      const { client_id, redirect_uri, state, nonce, code_challenge, code_challenge_method } = query;
 
       const client = await oauth.clients.getByClientId({ clientId: client_id });
       if (!client) {
@@ -163,6 +164,7 @@ const app = new Hono<AuthContext>()
         clientId: client.clientId,
         userId: user.id,
         redirectUri: redirect_uri,
+        nonce,
         codeChallenge: code_challenge,
         codeChallengeMethod: code_challenge_method,
       });
@@ -225,6 +227,7 @@ const app = new Hono<AuthContext>()
           userId: result.userId,
           client: result.client,
           issuer,
+          nonce: result.nonce,
         });
 
         return c.json({

--- a/packages/oauth/src/service/codes.ts
+++ b/packages/oauth/src/service/codes.ts
@@ -11,6 +11,7 @@ type DbCode = {
   client_id: string;
   user_id: string;
   redirect_uri: string;
+  nonce: string | null;
   code_challenge: string | null;
   code_challenge_method: string | null;
   expires_at: Date;
@@ -24,14 +25,15 @@ export const create = async (params: {
   clientId: string;
   userId: string;
   redirectUri: string;
+  nonce?: string;
   codeChallenge?: string;
   codeChallengeMethod?: "S256" | "plain";
 }): Promise<string> => {
-  const { clientId, userId, redirectUri, codeChallenge, codeChallengeMethod } = params;
+  const { clientId, userId, redirectUri, nonce, codeChallenge, codeChallengeMethod } = params;
 
   const [row] = await sql<{ code: string }[]>`
-    INSERT INTO oauth.codes (client_id, user_id, redirect_uri, code_challenge, code_challenge_method)
-    VALUES (${clientId}, ${userId}, ${redirectUri}, ${codeChallenge ?? null}, ${codeChallengeMethod ?? null})
+    INSERT INTO oauth.codes (client_id, user_id, redirect_uri, nonce, code_challenge, code_challenge_method)
+    VALUES (${clientId}, ${userId}, ${redirectUri}, ${nonce ?? null}, ${codeChallenge ?? null}, ${codeChallengeMethod ?? null})
     RETURNING code
   `;
 
@@ -47,12 +49,12 @@ export const consume = async (params: {
   clientId: string;
   redirectUri: string;
   codeVerifier?: string;
-}): Promise<{ userId: string; client: OAuthClient } | null> => {
+}): Promise<{ userId: string; client: OAuthClient; nonce: string | null } | null> => {
   const { code, clientId, redirectUri, codeVerifier } = params;
 
   // Get and validate code
   const [row] = await sql<DbCode[]>`
-    SELECT code, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, expires_at, used
+    SELECT code, client_id, user_id, redirect_uri, nonce, code_challenge, code_challenge_method, expires_at, used
     FROM oauth.codes
     WHERE code = ${code}
   `;
@@ -101,7 +103,7 @@ export const consume = async (params: {
   const client = await clients.getByClientId({ clientId });
   if (!client) return null;
 
-  return { userId: row.user_id, client };
+  return { userId: row.user_id, client, nonce: row.nonce };
 };
 
 /**

--- a/packages/oauth/src/service/tokens.ts
+++ b/packages/oauth/src/service/tokens.ts
@@ -114,6 +114,7 @@ export const getOpenIdConfiguration = (issuer: string) => ({
     "given_name",
     "family_name",
     "email",
+    "nonce",
     "groups",
   ],
   code_challenge_methods_supported: ["S256", "plain"],
@@ -127,8 +128,9 @@ export const createTokens = async (params: {
   userId: string;
   client: OAuthClient;
   issuer: string;
+  nonce?: string | null;
 }): Promise<{ accessToken: string; idToken: string | null; expiresIn: number }> => {
-  const { userId, client, issuer } = params;
+  const { userId, client, issuer, nonce } = params;
   const { privateKey, kid } = await getOrCreateKeyPair();
 
   // Load user to get uid for sub claim
@@ -163,6 +165,10 @@ export const createTokens = async (params: {
       uid: user.uid,
       id: user.id,
     };
+
+    if (nonce !== undefined && nonce !== null) {
+      idTokenClaims.nonce = nonce;
+    }
 
     if (client.scopes.includes("profile")) {
       idTokenClaims.name = user.displayName;


### PR DESCRIPTION
## Summary
Some OIDC clients, including Vaultwarden, require the provider to echo the `nonce` from the authorization request in the issued ID token. Without that claim, token validation fails even though the authorization code flow itself completed successfully.

This change:
- accepts `nonce` on the OIDC authorize endpoint
- stores the nonce with the authorization code
- passes the stored nonce through token exchange
- includes the nonce in issued ID tokens
- advertises `nonce` in OIDC discovery claims
- adds a migration for the new `oauth.codes.nonce` column

## Verification
- `nix-shell -p bun --run 'bun run --cwd packages/oauth typecheck'`